### PR TITLE
Update montage2d to scikit-image 0.20

### DIFF
--- a/medmnist/utils.py
+++ b/medmnist/utils.py
@@ -20,9 +20,9 @@ def save2d(imgs, labels, img_folder,
 
 
 def montage2d(imgs, n_channels, sel):
-
     sel_img = imgs[sel]
-    montage_arr = skimage_montage(sel_img, multichannel=(n_channels == 3))
+    channel_axis = 3 if n_channels == 3 else None                                                                                          
+    montage_arr = skimage_montage(sel_img, channel_axis=channel_axis)
     montage_img = Image.fromarray(montage_arr)
 
     return montage_img


### PR DESCRIPTION
The `multichannel` field in `skimage.util.montage` has been deprecated in version 0.20.

Update function call to work with the new API.

From the relase notes for 0.20:
Remove deprecated parameter multichannel; use channel_axis instead. [...] In skimage.util, this affects montage and apply_parallel ([#6583](https://github.com/scikit-image/scikit-image/pull/6583)).